### PR TITLE
Add example computing Mars and Phobos pose

### DIFF
--- a/examples/mars_phobos_sun_pose.py
+++ b/examples/mars_phobos_sun_pose.py
@@ -1,0 +1,32 @@
+import spiceypy as spice
+import numpy as np
+
+# Paths to the SPICE kernels needed for this example
+kernel_list = [
+    "/home/tt/corto/input/S07_Mars_Phobos_Deimos/kernels/naif0012.tls",
+    "/home/tt/corto/input/S07_Mars_Phobos_Deimos/kernels/mar097.bsp",
+    "/home/tt/corto/input/S07_Mars_Phobos_Deimos/kernels/pck00010.tpc",
+]
+
+for k in kernel_list:
+    spice.furnsh(k)
+
+spice_time = "2018-08-02T08:48:03.686"
+et = spice.utc2et(spice_time)
+
+# Positions relative to Mars
+phobos_pos, _ = spice.spkpos("PHOBOS", et, "J2000", "NONE", "MARS BARYCENTER")
+sun_pos, _ = spice.spkpos("SUN", et, "J2000", "NONE", "MARS BARYCENTER")
+
+# Orientations from J2000 to body-fixed frames
+mars_rot = spice.pxform("J2000", "IAU_MARS", et)
+phobos_rot = spice.pxform("J2000", "IAU_PHOBOS", et)
+sun_rot = spice.pxform("J2000", "IAU_SUN", et)
+
+print("Phobos position (km):", phobos_pos)
+print("Sun position (km):", sun_pos)
+print("Mars rotation matrix:\n", mars_rot)
+print("Phobos rotation matrix:\n", phobos_rot)
+print("Sun rotation matrix:\n", sun_rot)
+
+spice.kclear()

--- a/examples/pose_from_kernels.py
+++ b/examples/pose_from_kernels.py
@@ -1,0 +1,34 @@
+import spiceypy as spice
+import numpy as np
+
+# List of kernel paths
+# Local paths to the SPICE kernels needed for this example.  The ``mar097.bsp``
+# kernel contains ephemerides for Mars and its satellites (Phobos and Deimos)
+# from 1997 through 2050, which includes the example epoch below.  The
+# ``pck00010.tpc`` file provides planetary orientation data.
+kernel_list = [
+    "/home/tt/corto/input/S07_Mars_Phobos_Deimos/kernels/naif0012.tls",
+    "/home/tt/corto/input/S07_Mars_Phobos_Deimos/kernels/mar097.bsp",
+    "/home/tt/corto/input/S07_Mars_Phobos_Deimos/kernels/pck00010.tpc",
+]
+
+# Load kernels
+for k in kernel_list:
+    spice.furnsh(k)
+
+# Convert UTC to ET
+spice_time = "2018-08-02T08:48:03.686"
+et = spice.utc2et(spice_time)
+
+# Example: position of Phobos relative to Mars at the epoch
+pos, lt = spice.spkpos("PHOBOS", et, "J2000", "NONE", "MARS BARYCENTER")
+
+# Orientation matrix from J2000 to Mars body-fixed frame
+rot = spice.pxform("J2000", "IAU_MARS", et)
+
+print("Phobos position (km):", pos)
+print("Mars rotation matrix:")
+print(rot)
+
+# Always unload kernels when done
+spice.kclear()


### PR DESCRIPTION
## Summary
- demonstrate how to use SpiceyPy to find the positions of Phobos and the Sun
- show how to compute body-fixed orientation matrices for Mars, Phobos and the Sun

## Testing
- `pip install -r ci-requirements.txt`
- `pytest -q` *(fails: cannot open `libcspice.so`)*

------
https://chatgpt.com/codex/tasks/task_e_684070f987b48320bbf63a420d4727b3